### PR TITLE
Block Property Consistency Fixes

### DIFF
--- a/common/src/main/java/games/enchanted/verticalslabs/block/ModBlockBehaviours.java
+++ b/common/src/main/java/games/enchanted/verticalslabs/block/ModBlockBehaviours.java
@@ -13,6 +13,7 @@ public class ModBlockBehaviours {
     public static final BlockBehaviour.Properties NETHER_BRICK = BlockBehaviour.Properties.ofFullCopy(Blocks.NETHER_BRICKS);
     public static final BlockBehaviour.Properties COBBLED_DEEPSLATE = BlockBehaviour.Properties.ofFullCopy(Blocks.COBBLED_DEEPSLATE);
     public static final BlockBehaviour.Properties DEEPSLATE = BlockBehaviour.Properties.ofFullCopy(Blocks.DEEPSLATE);
+    public static final BlockBehaviour.Properties POLISHED_DEEPSLATE = BlockBehaviour.Properties.ofFullCopy(Blocks.POLISHED_DEEPSLATE);
     public static final BlockBehaviour.Properties DEEPSLATE_BRICK = BlockBehaviour.Properties.ofFullCopy(Blocks.DEEPSLATE_BRICKS);
     public static final BlockBehaviour.Properties DEEPSLATE_TILE = BlockBehaviour.Properties.ofFullCopy(Blocks.DEEPSLATE_TILES);
     public static final BlockBehaviour.Properties BLACKSTONE = BlockBehaviour.Properties.ofFullCopy(Blocks.BLACKSTONE);

--- a/common/src/main/java/games/enchanted/verticalslabs/block/ModBlocks.java
+++ b/common/src/main/java/games/enchanted/verticalslabs/block/ModBlocks.java
@@ -56,14 +56,14 @@ public class ModBlocks {
     public static final BlockAndItem VERTICAL_SMOOTH_SANDSTONE_SLAB = registerVerticalSlab("vertical_smooth_sandstone_slab", ModBlockBehaviours.STONE);
     public static final BlockAndItem VERTICAL_GRANITE_SLAB = registerVerticalSlab("vertical_granite_slab", ModBlockBehaviours.STONE);
     public static final BlockAndItem VERTICAL_ANDESITE_SLAB = registerVerticalSlab("vertical_andesite_slab", ModBlockBehaviours.STONE);
-    public static final BlockAndItem VERTICAL_RED_NETHER_BRICK_SLAB = registerVerticalSlab("vertical_red_nether_brick_slab", ModBlockBehaviours.STONE);
+    public static final BlockAndItem VERTICAL_RED_NETHER_BRICK_SLAB = registerVerticalSlab("vertical_red_nether_brick_slab", ModBlockBehaviours.NETHER_BRICK);
     public static final BlockAndItem VERTICAL_POLISHED_ANDESITE_SLAB = registerVerticalSlab("vertical_polished_andesite_slab", ModBlockBehaviours.STONE);
     public static final BlockAndItem VERTICAL_DIORITE_SLAB = registerVerticalSlab("vertical_diorite_slab", ModBlockBehaviours.STONE);
 
     public static final BlockAndItem VERTICAL_NETHER_BRICK_SLAB = registerVerticalSlab("vertical_nether_brick_slab", ModBlockBehaviours.NETHER_BRICK);
 
     public static final BlockAndItem VERTICAL_COBBLED_DEEPSLATE_SLAB = registerVerticalSlab("vertical_cobbled_deepslate_slab", ModBlockBehaviours.COBBLED_DEEPSLATE);
-    public static final BlockAndItem VERTICAL_POLISHED_DEEPSLATE_SLAB = registerVerticalSlab("vertical_polished_deepslate_slab", ModBlockBehaviours.DEEPSLATE);
+    public static final BlockAndItem VERTICAL_POLISHED_DEEPSLATE_SLAB = registerVerticalSlab("vertical_polished_deepslate_slab", ModBlockBehaviours.POLISHED_DEEPSLATE);
     public static final BlockAndItem VERTICAL_DEEPSLATE_BRICK_SLAB = registerVerticalSlab("vertical_deepslate_brick_slab", ModBlockBehaviours.DEEPSLATE_BRICK);
     public static final BlockAndItem VERTICAL_DEEPSLATE_TILE_SLAB = registerVerticalSlab("vertical_deepslate_tile_slab", ModBlockBehaviours.DEEPSLATE_TILE);
 


### PR DESCRIPTION
Fixes Red Nether Bricks and Polished Deepslate using the wrong block properties, fixing inconsistencies with sounds. (Breaking Red Nether Brick vertical slabs will no longer play the incorrect stone sound)

I understand that Polished Deepslate in vanilla technically has the same sound as normal Deepslate, however, it uses a unique sound event and this fixes any potential cases where the user replaces the Polished Deepslate sound event with a resource pack. I found this out because my partner is working on a sound pack that happens to do this but it doesn't apply to the vertical slabs for Polished Deepslate specifically. It should work fine with these changes