### PR TITLE
Fix NeoForge 1.21.11 build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ fabric_loader_version=0.18.1
 
 # NeoForge
 ## https://projects.neoforged.net/neoforged/neoforge
-neoforge_version=21.10.10-beta
+neoforge_version=21.11.42
 neoforge_loader_version_range=[2,)
 
 # Gradle

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,4 +48,4 @@ plugins {
 rootProject.name = 'enchanted-vertical-slabs'
 include("common")
 include("fabric")
-//include("neoforge")
+include("neoforge")


### PR DESCRIPTION
I updated neoforge_version in gradle.properties to 21.11.42 and uncommented include("neoforge") in settings.gradle. 

I have also tested it and it's working on my 1.21.11 server. Would it be possible to see the 1.21.11 version of the mod released on Modrinth if you get the chance please! :)